### PR TITLE
Fix express server duplicate listener

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,17 +1,16 @@
-import express from 'express'; 
-import cors from 'cors'; 
-const app = express(); 
-const port = 3001; 
- 
-app.use(cors()); 
-app.use(express.json()); 
- 
-app.get('/', (req, res) => { 
-    res.send('Hello from Express + TypeScript!'); 
-  }); 
-   
-app.listen(3001, () => console.log('API on :3001')); 
- 
-app.listen(port, () => { 
-  console.log(`Server running at http://localhost:${port}`); 
-}); 
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+const port = 3001;
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Hello from Express + TypeScript!');
+});
+
+app.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- remove extra app.listen call that caused double server initialization
- strip non-standard whitespace from server file

## Testing
- `pnpm run build` *(fails: Cannot find module 'express')*
- `pnpm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5c9c3e483278b668845a55557c5