### PR TITLE
Add side ad placeholders on homepage

### DIFF
--- a/frontend/src/components/Ads/SideAd.module.css
+++ b/frontend/src/components/Ads/SideAd.module.css
@@ -1,0 +1,31 @@
+.sideAd {
+  position: fixed;
+  top: 120px;
+  width: 160px;
+  height: 600px;
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  border: 2px dashed #dee2e6;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+  z-index: 1000;
+}
+
+.left {
+  left: 10px;
+}
+
+.right {
+  right: 10px;
+}
+
+.adContent {
+  color: #6c757d;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1200px) {
+  .sideAd {
+    display: none;
+  }
+}

--- a/frontend/src/components/Ads/SideAd.tsx
+++ b/frontend/src/components/Ads/SideAd.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from './SideAd.module.css';
+
+interface SideAdProps {
+  position: 'left' | 'right';
+}
+
+const SideAd: React.FC<SideAdProps> = ({ position }) => {
+  const adClass = `${styles.sideAd} ${position === 'left' ? styles.left : styles.right}`;
+  return (
+    <div className={adClass}>
+      <div className={styles.adContent}>広告スペース</div>
+    </div>
+  );
+};
+
+export default SideAd;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -5,6 +5,7 @@ import Layout from '../components/Layout/Layout';
 import HeroSlider from '../components/HeroSlider';
 import NewsSection from '../components/NewsSection/NewsSection';
 import Sidebar from '../components/Sidebar/Sidebar';
+import SideAd from '../components/Ads/SideAd';
 import SEOHead from '../components/SEO/SEOHead';
 import { 
   getLatestNewsPaginated, 
@@ -53,6 +54,8 @@ const Home: React.FC<HomeProps> = ({
         canonicalUrl={`${process.env.NEXT_PUBLIC_BASE_URL || ''}${currentPage > 1 ? `?page=${currentPage}` : ''}`}
       />
       <Layout>
+        <SideAd position="left" />
+        <SideAd position="right" />
         {/* HeroSliderを全ページで表示 */}
         <HeroSlider featuredNews={featuredNews} />
         


### PR DESCRIPTION
## Summary
- add `SideAd` component for fixed advertisement spaces
- show left/right ad placeholders on the homepage

## Testing
- `npm --prefix frontend run lint` *(fails: `next` not found)*
- `npm --prefix frontend run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411edee7f48327921febcb96b5ea85