### PR TITLE
Adjust HeroSlider layout

### DIFF
--- a/frontend/src/components/HeroSlider/HeroSlider.module.css
+++ b/frontend/src/components/HeroSlider/HeroSlider.module.css
@@ -6,7 +6,7 @@
   width: 100%;
   max-width: 1200px; /* home containerと同じ最大幅 */
   margin: 0 auto; /* 中央揃え */
-  padding: 0.75rem 15px 0 15px; /* home containerと同じ左右パディング */
+  padding: 0.75rem 10px 0 10px; /* 左右の余白を縮小 */
   background-color: var(--background-color);
 }
 
@@ -15,7 +15,7 @@
   width: 100%;
   max-width: 100%; /* 1400pxから100%に変更 */
   margin: 0 auto;
-  padding: 0 2rem; /* 左右の余白を確保 */
+  padding: 0 1rem; /* 左右余白を縮小 */
 }
 
 .swiper {
@@ -170,7 +170,7 @@
 /* レスポンシブ対応 */
 @media (max-width: 1200px) {
   .sliderContainer {
-    padding: 0 1.5rem;
+    padding: 0 0.75rem;
   }
 
   .swiper {
@@ -194,7 +194,7 @@
 
 @media (max-width: 992px) {
   .heroSlider {
-    padding: 0.75rem 10px 0 10px; /* タブレットでパディング調整 */
+    padding: 0.75rem 5px 0 5px; /* タブレットでパディング調整 */
   }
 
   .newsTitle {
@@ -224,11 +224,11 @@
 
 @media (max-width: 768px) {
   .heroSlider {
-    padding: 0.5rem 10px 0 10px; /* モバイルでパディング調整 */
+    padding: 0.5rem 5px 0 5px; /* モバイルでパディング調整 */
   }
 
   .sliderContainer {
-    padding: 0 1rem;
+    padding: 0 0.5rem;
   }
 
   .newsTitle {
@@ -272,11 +272,11 @@
 
 @media (max-width: 576px) {
   .heroSlider {
-    padding: 0.4rem 10px 0 10px; /* 最小画面でパディング調整 */
+    padding: 0.4rem 5px 0 5px; /* 最小画面でパディング調整 */
   }
 
   .sliderContainer {
-    padding: 0 0.5rem;
+    padding: 0 0.25rem;
   }
 
   .newsInfo {
@@ -320,7 +320,7 @@
   }
 
   .heroSlider {
-    padding: 0.4rem 10px 0 10px;
+    padding: 0.4rem 5px 0 5px;
   }
 }
 
@@ -366,7 +366,7 @@
 .heroGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1rem;
+  gap: 0.5rem;
   padding: 1rem;
   background: white;
   border-radius: 8px;

--- a/frontend/src/components/HeroSlider/HeroSlider.tsx
+++ b/frontend/src/components/HeroSlider/HeroSlider.tsx
@@ -20,8 +20,8 @@ const HeroSlider: React.FC<HeroSliderProps> = ({ featuredNews }) => {
       <div className={styles.sliderContainer}>
         <Swiper
           modules={[Autoplay, Navigation]}
-          spaceBetween={12}
-          slidesPerView={4}
+          spaceBetween={6}
+          slidesPerView={3}
           loop={true}
           autoplay={{
             delay: 4000,
@@ -36,19 +36,19 @@ const HeroSlider: React.FC<HeroSliderProps> = ({ featuredNews }) => {
           breakpoints={{
             320: {
               slidesPerView: 1,
-              spaceBetween: 8,
+              spaceBetween: 4,
             },
             576: {
               slidesPerView: 2,
-              spaceBetween: 10,
+              spaceBetween: 5,
             },
             768: {
               slidesPerView: 3,
-              spaceBetween: 12,
+              spaceBetween: 6,
             },
             1024: {
-              slidesPerView: 4,
-              spaceBetween: 12,
+              slidesPerView: 3,
+              spaceBetween: 6,
             },
           }}
           className={styles.swiper}

--- a/frontend/src/components/HeroSlider/index.tsx
+++ b/frontend/src/components/HeroSlider/index.tsx
@@ -34,7 +34,7 @@ const HeroSlider: React.FC<HeroSliderProps> = ({ featuredNews }) => {
       <div className={styles.heroSlider}>
         <div className={styles.staticHero}>
           <div className={styles.heroGrid}>
-            {featuredNews.slice(0, 4).map((news) => (
+            {featuredNews.slice(0, 3).map((news) => (
               <div key={news.id} className={styles.heroCard}>
                 <Link href={`/news/${news.slug}`}>
                   <div className={styles.imageContainer}>


### PR DESCRIPTION
## Summary
- show 3 items in the hero slider instead of 4
- shrink horizontal gaps and outer padding
- tweak fallback grid spacing

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418d1ffeac832781b5ed40cedd8ed9