### PR TITLE
Fix mobile news card line clamp

### DIFF
--- a/frontend/src/components/NewsSection/News.module.css
+++ b/frontend/src/components/NewsSection/News.module.css
@@ -490,6 +490,10 @@
     gap: 1rem;
   }
 
+  .newsHeaderList {
+    margin-bottom: 0.2rem;
+  }
+
   .newsCardList {
     min-height: 110px;
     height: auto;
@@ -502,12 +506,12 @@
   }
 
   .contentContainerList {
-    padding: 0.6rem;
+    padding: 0.5rem;
     width: 75%;
   }
 
   .newsTitleList {
-    font-size: 0.9rem;
+    font-size: 0.85rem;
   }
 
   .newsTitleList span {
@@ -523,6 +527,12 @@
   .category {
     font-size: 0.55rem !important;
     padding: 1px 4px !important;
+  }
+
+  .categoryTagSmall,
+  .categoryTagMoreSmall {
+    font-size: 0.5rem;
+    padding: 0.08rem 0.2rem;
   }
 
   .newsDateList, 
@@ -557,12 +567,12 @@
   }
 
   .contentContainerList {
-    padding: 0.5rem;
+    padding: 0.4rem;
     width: 75%;
   }
 
   .newsTitleList {
-    font-size: 0.85rem;
+    font-size: 0.8rem;
   }
 
   .newsTitleList span {
@@ -574,7 +584,7 @@
   }
 
   .newsHeaderList {
-    margin-bottom: 0.3rem;
+    margin-bottom: 0.15rem;
   }
 
   .categoryList,
@@ -602,12 +612,12 @@
   }
 
   .contentContainerList {
-    padding: 0.4rem;
+    padding: 0.3rem;
     width: 75%;
   }
 
   .newsTitleList {
-    font-size: 0.8rem;
+    font-size: 0.75rem;
   }
 
   .newsTitleList span {
@@ -621,12 +631,18 @@
     padding: 1px 3px !important;
   }
 
+  .categoryTagSmall,
+  .categoryTagMoreSmall {
+    font-size: 0.45rem;
+    padding: 0.05rem 0.2rem;
+  }
+
   .newsDateList {
     font-size: 0.55rem;
   }
 
   .newsHeaderList {
-    margin-bottom: 0.2rem;
+    margin-bottom: 0.1rem;
   }
 }
 
@@ -823,7 +839,7 @@
   
   .categoryTagSmall,
   .categoryTagMoreSmall {
-    font-size: 0.6rem;
+    font-size: 0.55rem;
     padding: 0.1rem 0.25rem;
   }
   

--- a/frontend/src/components/NewsSection/News.module.css
+++ b/frontend/src/components/NewsSection/News.module.css
@@ -73,8 +73,7 @@
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
-  min-height: 380px;
-  height: auto;
+  height: 380px;
   outline: none !important;
   -webkit-tap-highlight-color: transparent !important;
 }
@@ -562,54 +561,41 @@
 
 @media (max-width: 480px) {
   .newsCard {
-    min-height: 320px;
-    height: auto;
-  }
-  .newsCardList {
-    min-height: 120px;
-    height: auto;
+    min-height: 240px; /* さらに最小高さを縮小 */
   }
 
-  .imageContainerList {
-    width: 25%;
-    height: 80px;
-    min-width: 60px;
+  .imageContainer {
+    height: 120px; /* 画像高さも縮小 */
   }
 
-  .contentContainerList {
+  .contentContainer {
     padding: 0.4rem;
-    width: 75%;
   }
 
-  .newsTitleList {
-    font-size: 0.8rem;
+  .categoriesSmall {
+    margin-bottom: 0.1rem;
+    margin-top: 0;
   }
 
-  .newsTitleList span {
-    -webkit-line-clamp: 4;
+  .newsHeader {
+    margin-bottom: 0.1rem;
+    margin-top: 0;
+  }
+
+  .newsTitle {
+    font-size: 0.9rem;
+    margin-bottom: 0.3rem;
+    margin-top: 0;
   }
 
   .newsTitle span {
-    -webkit-line-clamp: 4;
+    -webkit-line-clamp: 2;
   }
 
-  .newsListContainer {
-    gap: 0.8rem;
-  }
-
-  .newsHeaderList {
-    margin-bottom: 0.15rem;
-  }
-
-  .categoryList,
-  .newsHeaderCategory,
-  .category {
-    font-size: 0.55rem !important;
-    padding: 0 4px !important;
-  }
-
-  .newsDateList {
-    font-size: 0.6rem;
+  .newsSummary {
+    font-size: 0.75rem;
+    margin-bottom: 0.6rem;
+    -webkit-line-clamp: 1; /* 1行に削減 */
   }
 }
 
@@ -668,19 +654,21 @@
   }
 }
 
-/* 複数カテゴリ用スタイル */
+/* 複数カテゴリ用スタイル - 上下余白を削除 */
 .categories {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 0;
+  margin-bottom: 0.5rem;
+  margin-top: 0; /* 上余白を削除 */
 }
 
 .categoriesSmall {
   display: flex;
   flex-wrap: wrap;
   gap: 0.3rem;
-  margin-bottom: 0;
+  margin-bottom: 0.3rem;
+  margin-top: 0; /* 上余白を削除 */
 }
 
 .categoryTag {
@@ -804,21 +792,23 @@
   transform: translateY(-1px);
 }
 
-/* ヘッダー部分の調整 */
+/* ヘッダー部分の調整 - 上下余白を削除 */
 .newsHeader {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.8rem;
-  min-height: 28px; /* 一定の高さを確保 */
+  margin-bottom: 0.5rem; /* 0.8remから0.5remに縮小 */
+  margin-top: 0; /* 上余白を削除 */
+  min-height: 28px;
 }
 
 .newsHeaderList {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
-  min-height: 24px; /* 一定の高さを確保 */
+  margin-bottom: 0.3rem; /* 0.5remから0.3remに縮小 */
+  margin-top: 0; /* 上余白を削除 */
+  min-height: 24px;
 }
 
 .newsHeaderDate,
@@ -830,43 +820,162 @@
   flex-shrink: 0; /* 日付が縮まないように */
 }
 
-/* レスポンシブ対応 */
+/* リストレイアウトの調整 */
 @media (max-width: 768px) {
+  .newsCardList {
+    height: auto; /* 固定高さを解除 */
+    min-height: 80px; /* 最小高さを設定 */
+  }
+
+  .contentContainerList {
+    padding: 0.6rem;
+    width: 75%;
+  }
+
+  .newsHeaderList {
+    margin-bottom: 0.2rem;
+    margin-top: 0;
+  }
+
+  .newsTitleList {
+    font-size: 1rem;
+    margin-top: 0;
+  }
+
+  .newsTitleList span {
+    -webkit-line-clamp: 2; /* タイトルを2行に制限 */
+  }
+}
+
+@media (max-width: 576px) {
+  .newsCardList {
+    min-height: 70px;
+  }
+
+  .contentContainerList {
+    padding: 0.4rem;
+  }
+
+  .newsHeaderList {
+    margin-bottom: 0.1rem;
+    margin-top: 0;
+  }
+
+  .newsTitleList {
+    font-size: 0.9rem;
+    margin-top: 0;
+  }
+}
+
+/* レスポンシブ対応 - モバイルでのカード高さ調整 */
+@media (max-width: 768px) {
+  .newsCard {
+    height: auto; /* 固定高さを解除してコンテンツに応じて調整 */
+    min-height: 280px; /* 最小高さを設定 */
+  }
+
+  .imageContainer {
+    height: 160px;
+  }
+
+  .contentContainer {
+    padding: 0.6rem; /* 0.8remから0.6remに縮小 */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* カテゴリの上下余白をさらに削除 */
   .categoriesSmall {
     gap: 0.2rem;
-    max-width: calc(100% - 60px); /* 日付用のスペースを確保 */
+    max-width: calc(100% - 60px);
+    margin-bottom: 0.2rem; /* 0.3remから0.2remに縮小 */
+    margin-top: 0;
   }
   
   .categoryTagSmall,
   .categoryTagMoreSmall {
     font-size: 0.65rem;
-    padding: 0 0.3rem;
+    padding: 0.15rem 0.3rem;
   }
   
   .newsHeader {
     align-items: flex-start;
     gap: 0.5rem;
+    margin-bottom: 0.3rem; /* さらに縮小 */
+    margin-top: 0;
   }
   
   .newsHeaderList {
     align-items: flex-start;
     gap: 0.5rem;
+    margin-bottom: 0.2rem; /* さらに縮小 */
+    margin-top: 0;
+  }
+
+  /* タイトル部分の調整 */
+  .newsTitle {
+    font-size: 1rem;
+    margin-bottom: 0.5rem; /* 0.8remから0.5remに縮小 */
+    margin-top: 0;
+    line-height: 1.3;
+  }
+
+  .newsTitle span {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    line-height: 1.3;
   }
 }
 
 @media (max-width: 576px) {
+  .newsCard {
+    height: auto; /* コンテンツに応じて調整 */
+    min-height: 260px; /* 最小高さを少し縮小 */
+  }
+  
+  .imageContainer {
+    height: 140px;
+  }
+
+  .contentContainer {
+    padding: 0.5rem; /* さらに縮小 */
+  }
+
+  /* カテゴリの余白をさらに削除 */
   .categoriesSmall {
-    max-width: calc(100% - 50px); /* より狭い画面での調整 */
+    max-width: calc(100% - 50px);
+    margin-bottom: 0.1rem; /* さらに縮小 */
+    margin-top: 0;
   }
   
   .categoryTagSmall,
   .categoryTagMoreSmall {
-    font-size: 0.55rem;
-    padding: 0 0.25rem;
+    font-size: 0.6rem;
+    padding: 0.1rem 0.25rem;
   }
-  
-  .newsHeaderDate,
-  .newsDateList {
-    font-size: 0.7rem;
+
+  .newsHeader {
+    margin-bottom: 0.2rem; /* さらに縮小 */
+    margin-top: 0;
+  }
+
+  .newsTitle {
+    font-size: 0.95rem;
+    margin-bottom: 0.4rem; /* さらに縮小 */
+    margin-top: 0;
+  }
+
+  /* タイトルが短い場合の行数制限 */
+  .newsTitle span {
+    -webkit-line-clamp: 2; /* 3行から2行に削減 */
+  }
+
+  .newsSummary {
+    font-size: 0.8rem;
+    margin-bottom: 0.8rem;
+    -webkit-line-clamp: 2;
   }
 }

--- a/frontend/src/components/NewsSection/News.module.css
+++ b/frontend/src/components/NewsSection/News.module.css
@@ -73,7 +73,8 @@
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
-  height: 380px;
+  min-height: 380px;
+  height: auto;
   outline: none !important;
   -webkit-tap-highlight-color: transparent !important;
 }
@@ -112,7 +113,7 @@
   left: 8px;
   background-color: var(--secondary-color) !important;
   color: white !important;
-  padding: 3px 8px !important;
+  padding: 0 8px !important;
   border-radius: 3px !important;
   font-size: 0.65rem !important;
   font-weight: 600 !important;
@@ -153,7 +154,7 @@
 .newsHeaderCategory {
   background-color: var(--secondary-color) !important;
   color: white !important;
-  padding: 3px 8px !important;
+  padding: 0 8px !important;
   border-radius: 3px !important;
   font-size: 0.65rem !important;
   font-weight: 600 !important;
@@ -319,7 +320,7 @@
 .categoryList {
   background-color: var(--secondary-color) !important;
   color: white !important;
-  padding: 3px 8px !important;
+  padding: 0 8px !important;
   border-radius: 3px !important;
   font-size: 0.65rem !important;
   font-weight: 600 !important;
@@ -479,7 +480,8 @@
   }
 
   .newsCard {
-    height: 320px;
+    min-height: 320px;
+    height: auto;
   }
   
   .imageContainer {
@@ -512,6 +514,10 @@
 
   .newsTitleList {
     font-size: 0.85rem;
+  }
+
+  .newsTitle span {
+    -webkit-line-clamp: 4;
   }
 
   .newsTitleList span {
@@ -555,6 +561,10 @@
 }
 
 @media (max-width: 480px) {
+  .newsCard {
+    min-height: 320px;
+    height: auto;
+  }
   .newsCardList {
     min-height: 120px;
     height: auto;
@@ -579,6 +589,10 @@
     -webkit-line-clamp: 4;
   }
 
+  .newsTitle span {
+    -webkit-line-clamp: 4;
+  }
+
   .newsListContainer {
     gap: 0.8rem;
   }
@@ -591,7 +605,7 @@
   .newsHeaderCategory,
   .category {
     font-size: 0.55rem !important;
-    padding: 1px 4px !important;
+    padding: 0 4px !important;
   }
 
   .newsDateList {
@@ -600,6 +614,10 @@
 }
 
 @media (max-width: 360px) {
+  .newsCard {
+    min-height: 320px;
+    height: auto;
+  }
   .newsCardList {
     min-height: 120px;
     height: auto;
@@ -624,17 +642,21 @@
     -webkit-line-clamp: 4;
   }
 
+  .newsTitle span {
+    -webkit-line-clamp: 4;
+  }
+
   .categoryList,
   .newsHeaderCategory,
   .category {
     font-size: 0.5rem !important;
-    padding: 1px 3px !important;
+    padding: 0 3px !important;
   }
 
   .categoryTagSmall,
   .categoryTagMoreSmall {
     font-size: 0.45rem;
-    padding: 0.05rem 0.2rem;
+    padding: 0 0.2rem;
   }
 
   .newsDateList {
@@ -651,14 +673,14 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0;
 }
 
 .categoriesSmall {
   display: flex;
   flex-wrap: wrap;
   gap: 0.3rem;
-  margin-bottom: 0.3rem;
+  margin-bottom: 0;
 }
 
 .categoryTag {
@@ -676,7 +698,7 @@
 .categoryTagSmall {
   background-color: var(--category-color, var(--secondary-color));
   color: white;
-  padding: 0.2rem 0.4rem;
+  padding: 0 0.4rem;
   border-radius: 3px;
   font-size: 0.7rem;
   font-weight: 500;
@@ -763,7 +785,7 @@
 .categoryTagMoreSmall {
   background-color: var(--category-color, var(--secondary-color));
   color: white;
-  padding: 0.2rem 0.4rem;
+  padding: 0 0.4rem;
   border-radius: 3px;
   font-size: 0.7rem;
   font-weight: 500;
@@ -818,7 +840,7 @@
   .categoryTagSmall,
   .categoryTagMoreSmall {
     font-size: 0.65rem;
-    padding: 0.15rem 0.3rem;
+    padding: 0 0.3rem;
   }
   
   .newsHeader {
@@ -840,7 +862,7 @@
   .categoryTagSmall,
   .categoryTagMoreSmall {
     font-size: 0.55rem;
-    padding: 0.1rem 0.25rem;
+    padding: 0 0.25rem;
   }
   
   .newsHeaderDate,

--- a/frontend/src/components/NewsSection/News.module.css
+++ b/frontend/src/components/NewsSection/News.module.css
@@ -491,7 +491,8 @@
   }
 
   .newsCardList {
-    height: 90px;
+    min-height: 110px;
+    height: auto;
   }
 
   .imageContainerList {
@@ -509,15 +510,19 @@
     font-size: 0.9rem;
   }
 
+  .newsTitleList span {
+    -webkit-line-clamp: 4;
+  }
+
   .newsTitle {
     font-size: 0.95rem;
   }
 
-  .categoryList, 
+  .categoryList,
   .newsHeaderCategory,
   .category {
-    font-size: 0.6rem !important;
-    padding: 2px 6px !important;
+    font-size: 0.55rem !important;
+    padding: 1px 4px !important;
   }
 
   .newsDateList, 
@@ -541,7 +546,8 @@
 
 @media (max-width: 480px) {
   .newsCardList {
-    height: 80px;
+    min-height: 120px;
+    height: auto;
   }
 
   .imageContainerList {
@@ -557,7 +563,10 @@
 
   .newsTitleList {
     font-size: 0.85rem;
-    -webkit-line-clamp: 2;
+  }
+
+  .newsTitleList span {
+    -webkit-line-clamp: 4;
   }
 
   .newsListContainer {
@@ -582,7 +591,8 @@
 
 @media (max-width: 360px) {
   .newsCardList {
-    height: 75px;
+    min-height: 120px;
+    height: auto;
   }
 
   .imageContainerList {
@@ -598,7 +608,10 @@
 
   .newsTitleList {
     font-size: 0.8rem;
-    -webkit-line-clamp: 2;
+  }
+
+  .newsTitleList span {
+    -webkit-line-clamp: 4;
   }
 
   .categoryList,


### PR DESCRIPTION
## Summary
- allow longer titles for mobile news cards

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419c1d27f88327a2b2c4b98151e325